### PR TITLE
Fix main/default branch.  Update prebuilds code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This script automatically creates demo repositories for workshop attendees by fo
    - `admin:org` (Full control of orgs and teams, read and write org projects)
    - `workflow` (Update GitHub Action workflows)
    - `delete_repo` (Only needed if you plan to run the cleanup script.  It's 3 repos per attendee so likely the easiest way to clean up.)
+   - `codespace` (Read and write access to Codespaces configurations - Only if you want Codespaces prebuilds) -- SKIP THIS until an API exists for pre-builds...
 3. **Admin access** to the target organization where repositories will be created
 4. **Access** to the source repository that will be forked
 
@@ -302,6 +303,7 @@ Prebuilds will **NOT** be triggered on:
 - ❌ Regular code commits and pushes
 - ❌ Pull request creation or updates
 - ❌ Changes to non-devcontainer files
+- ❌ Repos other than octocatSupply
 
 ## Security Notes
 


### PR DESCRIPTION
This pull request updates the demo repository setup workflow to improve branch handling, enforce GitHub conventions, and clarify Codespaces prebuild support. The most significant changes ensure that all created repositories use `main` as the default branch and restrict Codespaces prebuilds to specific repositories, with documentation indicating there is no prebuilds API today. 